### PR TITLE
Set artifactType in fallback descriptor if present

### DIFF
--- a/pkg/v1/remote/referrers.go
+++ b/pkg/v1/remote/referrers.go
@@ -49,6 +49,10 @@ func fallbackTag(d name.Digest) name.Tag {
 func (f *fetcher) fetchReferrers(ctx context.Context, filter map[string]string, d name.Digest) (v1.ImageIndex, error) {
 	// Check the Referrers API endpoint first.
 	u := f.url("referrers", d.DigestStr())
+	artifactType, ok := filter["artifactType"]
+	if ok {
+		u.Query().Add("artifactType", artifactType)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/v1/remote/write.go
+++ b/pkg/v1/remote/write.go
@@ -562,9 +562,10 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 		return err
 	}
 	var mf struct {
-		MediaType types.MediaType `json:"mediaType"`
-		Subject   *v1.Descriptor  `json:"subject,omitempty"`
-		Config    struct {
+		ArtifactType string          `json:"artifactType,omitempty"`
+		MediaType    types.MediaType `json:"mediaType"`
+		Subject      *v1.Descriptor  `json:"subject,omitempty"`
+		Config       struct {
 			MediaType types.MediaType `json:"mediaType"`
 		} `json:"config"`
 	}
@@ -605,8 +606,12 @@ func (w *writer) commitManifest(ctx context.Context, t Taggable, ref name.Refere
 			if err != nil {
 				return err
 			}
+			artifactType := mf.ArtifactType
+			if artifactType == "" {
+				artifactType = string(mf.Config.MediaType)
+			}
 			desc := v1.Descriptor{
-				ArtifactType: string(mf.Config.MediaType),
+				ArtifactType: artifactType,
 				MediaType:    mf.MediaType,
 				Digest:       h,
 				Size:         size,


### PR DESCRIPTION
As per spec, `artifactType` should be set to the artifact's `artifactType` in the referrers fallback scheme if present:

https://github.com/opencontainers/distribution-spec/blob/11b8e3fba7d2d7329513d0cff53058243c334858/spec.md?plain=1#L504

*EDIT*

A similar problem exists in the in-memory registry implementation. Second commit addresses this.

*EDIT*

Also added artifactType to the referrers query filter if supplied